### PR TITLE
refactor: useFetcher の型注釈をシンプルに。

### DIFF
--- a/15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsx
+++ b/15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsx
@@ -10,11 +10,10 @@ interface MessageFormProps {
 }
 
 export default function MessageForm({ errorMessage }: MessageFormProps) {
-  const fetcher = useFetcher();
+  const fetcher = useFetcher<typeof action>();
   const formRef = useRef<HTMLFormElement>(null);
   const errMsg =
-    errorMessage ??
-    (fetcher.data as Awaited<ReturnType<typeof action>>)?.errorMessage;
+    errorMessage ?? fetcher.data?.errorMessage;
 
   useEffect(() => {
     if (fetcher.state === "idle") {


### PR DESCRIPTION
fix: https://github.com/klemiwary/Riakuto-StartingReact-ja5.0/issues/4

This pull request makes a small improvement to the type safety and readability of the `MessageForm` component by updating the `useFetcher` hook and simplifying the error message extraction.

* Updated `useFetcher` to include the type of `action` for better type safety. (`15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsx`, [15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsxL13-R16](diffhunk://#diff-45e1dfde43e2159a2992bfcbab21a2235d678a578429d6b4c67461fda134dd69L13-R16))
* Simplified the error message extraction logic by removing redundant type casting and directly accessing `fetcher.data?.errorMessage`. (`15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsx`, [15-form/02-actions/03-route-action/app/components/message-form.fetcher.tsxL13-R16](diffhunk://#diff-45e1dfde43e2159a2992bfcbab21a2235d678a578429d6b4c67461fda134dd69L13-R16))